### PR TITLE
Add libraries in requirements.txt

### DIFF
--- a/InstallRequiredLibs.bat
+++ b/InstallRequiredLibs.bat
@@ -1,2 +1,1 @@
-pip install requests
-pip install pyyaml
+pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ RMMUD is short for "RandomGgames' Minecraft Mod Updater and Downloader". This is
 
 # Requirements
 - Python 3. https://www.python.org/downloads/
-- Requests library. `pip install requests` (Can be installed via the provided InstallRequiredLibs.bat file)
-- YAML library. `pip install pyyaml` (Can be installed via the provided InstallRequiredLibs.bat file)
+- Libraries. `pip install -r requirements.txt`
 - Your own CurseForge API key if using Curseforge links. https://console.curseforge.com/?#/api-keys
   - Log in
   - Close the popup menu in the middle of the screen if it pops up

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ RMMUD is short for "RandomGgames' Minecraft Mod Updater and Downloader". This is
 
 # Requirements
 - Python 3. https://www.python.org/downloads/
-- Libraries. `pip install -r requirements.txt`
+- Libraries. `pip install -r requirements.txt` (Can be installed via the provided InstallRequiredLibs.bat file)
 - Your own CurseForge API key if using Curseforge links. https://console.curseforge.com/?#/api-keys
   - Log in
   - Close the popup menu in the middle of the screen if it pops up

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML>=6.0.1
+requests>=2.31.0


### PR DESCRIPTION
You should add libraries [in a `requirements.txt` file](https://docs.python.org/3/tutorial/venv.html) instead of a batch file (I kept the batch file because it'll be easier for other people to install), you can now install it with a single command: `pip install -r requirements.txt`.